### PR TITLE
Add Prediction field to ChatCompletionRequest

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -263,6 +263,8 @@ type ChatCompletionRequest struct {
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 	// Metadata to store with the completion.
 	Metadata map[string]string `json:"metadata,omitempty"`
+	// Configuration for a predicted output.
+	Prediction *Prediction `json:"prediction,omitempty"`
 }
 
 type StreamOptions struct {
@@ -328,6 +330,11 @@ type LogProb struct {
 type LogProbs struct {
 	// Content is a list of message content tokens with log probability information.
 	Content []LogProb `json:"content"`
+}
+
+type Prediction struct {
+	Content string `json:"content"`
+	Type    string `json:"type"`
 }
 
 type FinishReason string

--- a/common.go
+++ b/common.go
@@ -13,8 +13,10 @@ type Usage struct {
 
 // CompletionTokensDetails Breakdown of tokens used in a completion.
 type CompletionTokensDetails struct {
-	AudioTokens     int `json:"audio_tokens"`
-	ReasoningTokens int `json:"reasoning_tokens"`
+	AudioTokens              int `json:"audio_tokens"`
+	ReasoningTokens          int `json:"reasoning_tokens"`
+	AcceptedPredictionTokens int `json:"accepted_prediction_tokens"`
+	RejectedPredictionTokens int `json:"rejected_prediction_tokens"`
 }
 
 // PromptTokensDetails Breakdown of tokens used in the prompt.


### PR DESCRIPTION
## Description

Adding the Prediction field as outlined in the OpenAI documentation: https://platform.openai.com/docs/api-reference/chat/create#chat-create-prediction.

Verified that with the Prediction field added, the API returns values for how many predictions tokens it used.
<img width="383" alt="image" src="https://github.com/user-attachments/assets/93d013ba-2917-4bd1-9c8a-fcb17297ef23" />

